### PR TITLE
Add items.db and Update main.py at STEP3-4

### DIFF
--- a/db/items.db
+++ b/db/items.db
@@ -1,0 +1,1 @@
+CREATE TABLE items (            id INTEGER AUTO INCREMENT, name TEXT NOT NULL, category TEXT NOT NULL);

--- a/python/main.py
+++ b/python/main.py
@@ -2,6 +2,7 @@ import os
 import logging
 import pathlib
 import json
+import sqlite3
 from fastapi import FastAPI, Form, HTTPException
 from fastapi.responses import FileResponse
 from fastapi.middleware.cors import CORSMiddleware
@@ -25,6 +26,7 @@ def root():
 
 @app.get("/items")
 def get_item():
+    """
     if os.path.isfile("item.json"):
         with open("item.json") as file:
             item_dict = json.load(file)
@@ -32,10 +34,21 @@ def get_item():
         item_dict = {"item": []}
     
     return item_dict
+    """
+    with sqlite3.connect("../db/mercari.sqlite3") as conn:
+        #カーソル
+        cur = conn.cursor()
+        #データの取得
+        cur.execute("SELECT * FROM items")
+        item_obj = cur.fetchall()
+        #変更の反映
+        conn.commit()
+    
+    return item_obj
 
 @app.post("/items")
 def add_item(name: str = Form(...), category: str = Form(...)):
-    #item.jsonが既にあるとき
+    """#item.jsonが既にあるとき
     if os.path.isfile("item.json"):
         with open("item.json") as file:
             item_dict = json.load(file)
@@ -49,6 +62,24 @@ def add_item(name: str = Form(...), category: str = Form(...)):
     with open("item.json", "w") as file:
         json.dump(item_dict, file)
     logger.info(f"Receive item: {name}")
+    """
+
+    with sqlite3.connect("../db/mercari.sqlite3") as conn:
+        #カーソル
+        cur = conn.cursor()
+        #テーブルがなければ作成
+        cur.execute("CREATE TABLE IF NOT EXISTS items (\
+            id INTEGER AUTO_INCREMENT, \
+            name TEXT NOT NULL,\
+            category TEXT NOT NULL\
+            )")
+
+        #受け取ったデータを追加
+        #(?, ?)はプレースホルダ
+        cur.execute("INSERT INTO items (name, category) VALUES (?, ?)", (name, category))
+        #変更の反映
+        conn.commit()
+
     return {"message": f"item received: {name}"}
 
 @app.get("/image/{items_image}")


### PR DESCRIPTION
## What
main.pyでitems.jsonに入れていた情報をdb/mercari.sqlite3で管理するようにしました。
mercari.sqlite3のアイテムテーブルのスキーマをitems.dbに、ターミナルを使って保存しました。
```
$ cd mercari-build-training-2022/db
$ sqlite3 mercari.sqlite3 
sqlite> .output items.db
sqlite> .schema
```

## CHECKS :warning:

Please make sure you are aware of the following.

- [x] **The changes in this PR doesn't have private information
